### PR TITLE
side-to-side is not valid in netbox picking right-to-left

### DIFF
--- a/device-types/Juniper/ACX7020-AC.yaml
+++ b/device-types/Juniper/ACX7020-AC.yaml
@@ -6,7 +6,7 @@ slug: juniper-acx7020-ac
 u_height: 1
 weight: 4.45
 weight_unit: kg
-airflow: side-to-side
+airflow: right-to-left
 is_full_depth: false
 comments: '[Juniper ACX7020-AC Datasheet](https://www.juniper.net/us/en/products/routers/acx-series/acx7000-family-cloud-metro-routers/acx7000-line/acx7020-cloud-metro-routers-datasheet.html)'
 front_image: true


### PR DESCRIPTION
In NetBox, the airflow options don't include `side-to-side`. Choosing `right-to-left` as alternative option which is closest to the datasheet.